### PR TITLE
Ensure `num_rows` is respected throughout the code.

### DIFF
--- a/src/cast.asm
+++ b/src/cast.asm
@@ -292,35 +292,41 @@ cast_odd_row:
 
 cast_even_column:
 	exx
-		ld de, 64
+		ld de, 128		; Not 256 (yet) because I'd need to be more careful about offset being signed
+						; in the loop below.
 	exx
 
 	push hl
 
-	REPT 24, row
+	REPT num_rows, row
+		_offset equ (row & 1)*64
+
 		IF row
 			pop hl
 			inc_x
 			push hl
 		ENDIF
 		call cast_even_diamond
-		ld (ix + 0), l
+		ld (ix + _offset), l
 
 		pop hl
 		inc_y
 		push hl
 		call cast_odd_diamond
-		ld (ix + 32), h
+		ld (ix + _offset + 32), h
 
-		exx
-		add ix, de
-		exx
+		IF _offset = 64
+			exx
+			add ix, de
+			exx
+		ENDIF
 	ENDM
 
 	pop hl
 	inc_x
 	call cast_even_diamond
-	ld (ix + 0), l
+	_here equ 23
+	ld (ix + (num_rows & 3)*64), l
 
 	ret
 
@@ -343,36 +349,40 @@ cast_even_column:
 
 cast_odd_column:
 	exx
-		ld de, 64
+		ld de, 128
 	exx
 
 	push hl
 
-	REPT 24, row
+	REPT num_rows, row
+		_offset equ (row & 1)*64
+
 		IF row
 			pop hl
 			inc_y
 			push hl
 		ENDIF
 		call cast_even_diamond
-		ld (ix + 0), h
+		ld (ix + _offset), h
 
 		pop hl
 		inc_x
 		push hl
 		call cast_odd_diamond
-		ld (ix + 32), l
+		ld (ix + _offset + 32), l
 
-		exx
-		add ix, de
-		exx
+		IF _offset = 64
+			exx
+			add ix, de
+			exx
+		ENDIF
 	ENDM
 
 	pop hl
 	inc_y
 	call cast_even_diamond
-	ld (ix + 0), h
-
+	ld (ix + (num_rows & 1)*64), h
+	
 	ret
 
 ;
@@ -405,3 +415,4 @@ cast_map:
 	pop hl
 	inc_x
 	jp cast_even_row			; i.e. call cast_even_row; ret
+	

--- a/src/cast.asm
+++ b/src/cast.asm
@@ -326,7 +326,7 @@ cast_even_column:
 	inc_x
 	call cast_even_diamond
 	_here equ 23
-	ld (ix + (num_rows & 3)*64), l
+	ld (ix + (num_rows & 1)*64), l
 
 	ret
 

--- a/src/cast.asm
+++ b/src/cast.asm
@@ -382,7 +382,7 @@ cast_odd_column:
 	inc_y
 	call cast_even_diamond
 	ld (ix + (num_rows & 1)*64), h
-	
+
 	ret
 
 ;
@@ -415,4 +415,3 @@ cast_map:
 	pop hl
 	inc_x
 	jp cast_even_row			; i.e. call cast_even_row; ret
-	

--- a/src/cast.asm
+++ b/src/cast.asm
@@ -49,13 +49,23 @@
 ;	for any given top cube are in a single byte. So all levels can be tested
 ;	at once with a single CP, at least after a run through the log2 table.
 ;
+;	----
+;
+;	Note on axes in use here:
+;
+;	If B were at the origin then:
+;
+;		- R would be at (1, 0);
+;		- L would be at (0, 1); and
+;		- F would be at (1, 1).
+;
 
 floorcolour	equ	0x00	; i.e. colour 0
 cubetop		equ 0x1c	; i.e. colour 1
 leftwall	equ 0xe0	; i.e. colour 2
 rightwall	equ	0xfc	; i.e. colour 3
 
-cast MACRO mask
+cast_diamond MACRO mask
 	; Read from (x, y).
 	ld b, (hl)		; i.e. b = 'front'.
 	
@@ -174,8 +184,13 @@ _front_ge_right_and_back:
 
 ENDM
 
-cast_even:	cast 0x48
-cast_odd:	cast 0x90
+;
+;	Two instantiations of cast_diamond are assembled, one that generates the correct bit
+;	patterns for even rows and one for odds. Different bit patterns are used for
+;	alternate rows in order slightly to reduce costs in tile output.
+;
+cast_even_diamond:	cast_diamond 0x48	; i.e. a diamond on an even row: rows 0, 2, 4 ...
+cast_odd_diamond:	cast_diamond 0x90	; i.e. a diamond on an odd row: rows 1, 3, 5 ...
 
 ;
 ;	Current map location in the top left of the display.
@@ -193,7 +208,7 @@ map_location:	dw 0xc0ff
 cast_even_row:
 	; Fill the first diamond.
 	push hl
-	call cast_even
+	call cast_even_diamond
 	ld (ix+0), l
 	ld (ix+1), h
 
@@ -208,7 +223,7 @@ cast_even_row:
 		ENDIF
 
 		; Cast and store.
-		call cast_even
+		call cast_even_diamond
 		ld (ix+(offset*2)+2), l
 		ld (ix+(offset*2)+3), h
 	ENDM
@@ -229,7 +244,7 @@ cast_even_row:
 cast_odd_row:
 	; Fill the single triangle on the left.
 	push hl
-	call cast_odd
+	call cast_odd_diamond
 	ld (ix+0), h
 
 	; Fill all the intermediate diamonds.
@@ -240,7 +255,7 @@ cast_odd_row:
 		push hl
 
 		; Cast and store.
-		call cast_odd
+		call cast_odd_diamond
 		ld (ix+(offset*2)+1), l
 		ld (ix+(offset*2)+2), h
 	ENDM
@@ -250,7 +265,7 @@ cast_odd_row:
 	pop hl
 	inc_x_dec_y
 	
-	call cast_odd
+	call cast_odd_diamond
 	ld (ix+31), l
 
 	; Advance IX and return.
@@ -288,13 +303,13 @@ cast_even_column:
 			inc_x
 			push hl
 		ENDIF
-		call cast_even
+		call cast_even_diamond
 		ld (ix + 0), l
 
 		pop hl
 		inc_y
 		push hl
-		call cast_odd
+		call cast_odd_diamond
 		ld (ix + 32), h
 
 		exx
@@ -304,7 +319,7 @@ cast_even_column:
 
 	pop hl
 	inc_x
-	call cast_even
+	call cast_even_diamond
 	ld (ix + 0), l
 
 	ret
@@ -339,13 +354,13 @@ cast_odd_column:
 			inc_y
 			push hl
 		ENDIF
-		call cast_even
+		call cast_even_diamond
 		ld (ix + 0), h
 
 		pop hl
 		inc_x
 		push hl
-		call cast_odd
+		call cast_odd_diamond
 		ld (ix + 32), l
 
 		exx
@@ -355,7 +370,7 @@ cast_odd_column:
 
 	pop hl
 	inc_y
-	call cast_even
+	call cast_even_diamond
 	ld (ix + 0), h
 
 	ret

--- a/src/drawtiles.asm
+++ b/src/drawtiles.asm
@@ -10,8 +10,9 @@ video_pointers:
 	dw 0x40e0, 0x40c0, 0x40a0, 0x4080, 0x4060, 0x4040, 0x4020, 0x4000
 
 ;
-;	Ephemeral work buffer for current triangle colours, 32 columns by 49 rows,
-;	indexed linearly from top left to bottom right.
+;	Ephemeral work buffer for current triangle colours, 32 columns by
+;	49 rows (assuming a 24-row final output), indexed linearly from top
+;	left to bottom right.
 ;
 ;	Even lines contain the colour index of [0, 3] shifted up to bits 6 and 7;
 ;	odd lines use bits 3 and 2.
@@ -19,14 +20,14 @@ video_pointers:
 ;	Currently no alignment requirement; cf. the use of (IX+n) in cast.asm.
 ;
 
-triangle_map:	ds 32*49
+triangle_map:	ds 32*(num_rows*2 + 1)
 
 ;
 ;	Map of tiles currently on screen.
 ;
 ;	No particular alignment requirements right now.
 ;
-output_map: 	ds 32*24, 1
+output_map: 	ds 32*num_rows, 1
 
 ;
 ;	Outputs the current state of the triangle map, in full.

--- a/src/main.asm
+++ b/src/main.asm
@@ -3,7 +3,7 @@
 	;
 	; Defines the number of rows calculated and drawn.
 	;
-	num_rows equ 24
+	num_rows equ 14
 
 	INCLUDE "src/tiles.inc"
 	INCLUDE "src/drawtiles.asm"

--- a/src/main.asm
+++ b/src/main.asm
@@ -1,9 +1,13 @@
 	org $8000
 
 	;
-	; Defines the number of rows calculated and drawn.
+	;	Defines the number of rows calculated and drawn.
 	;
-	num_rows equ 14
+	;	Due to current contents of video_pointers in drawtiles.asm, the rows drawn
+	;	will always be those at the bottom of the display. Adjust that if you
+	;	want to use some other portion for output.
+	;
+	num_rows equ 24
 
 	INCLUDE "src/tiles.inc"
 	INCLUDE "src/drawtiles.asm"

--- a/src/scroll.asm
+++ b/src/scroll.asm
@@ -296,4 +296,3 @@ _scroll_table:
 	dw move_view_down			; 1101 : down.
 	dw move_view_up				; 1110 : up.
 	dw _no_scroll				; 1111 : nothing.
-	

--- a/src/scroll.asm
+++ b/src/scroll.asm
@@ -27,8 +27,8 @@ fix_up:
 
 	ret
 
-triangle_map_size equ 32*49
-triangle_map_end equ triangle_map + triangle_map_size - 1
+triangle_map_size	equ 32*(num_rows*2 + 1)
+triangle_map_end	equ triangle_map + triangle_map_size - 1
 
 ;
 ;	Moves the view left one position and down one position


### PR DESCRIPTION
Including for buffer sizes, unrolled loops, the lot.